### PR TITLE
docs(zh): sync update

### DIFF
--- a/packages/docs/zh/guide/advanced/composition-api.md
+++ b/packages/docs/zh/guide/advanced/composition-api.md
@@ -9,7 +9,7 @@
 
 ## 在 `setup` 中访问路由和当前路由
 
-因为我们在 `setup` 里面没有访问 `this`，所以我们不能再直接访问 `this.$router` 或 `this.$route`。作为替代，我们使用 `useRouter` 函数：
+因为我们在 `setup` 里面没有访问 `this`，所以我们不能再直接访问 `this.$router` 或 `this.$route`。作为替代，我们使用 `useRouter` 和 `useRoute` 函数：
 
 ```js
 import { useRouter, useRoute } from 'vue-router'

--- a/packages/docs/zh/guide/advanced/extending-router-link.md
+++ b/packages/docs/zh/guide/advanced/extending-router-link.md
@@ -84,7 +84,7 @@ export default {
 <template>
   <AppLink
     v-bind="$attrs"
-    class="inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 focus:outline-none transition duration-150 ease-in-out hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out"
+    class="inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out"
     active-class="border-indigo-500 text-gray-900 focus:border-indigo-700"
     inactive-class="text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300"
   >

--- a/packages/docs/zh/guide/advanced/lazy-loading.md
+++ b/packages/docs/zh/guide/advanced/lazy-loading.md
@@ -75,6 +75,7 @@ export default defineConfig({
             './src/UserProfileEdit',
           ],
         },
+      },
     },
   },
 })

--- a/packages/docs/zh/index.md
+++ b/packages/docs/zh/index.md
@@ -9,7 +9,7 @@ hero:
   text: Vue.js 的官方路由
   tagline: Expressive, configurable and convenient routing for Vue.js
   image:
-    src: /logo.png
+    src: /logo.svg
     alt: Vue Router
   actions:
     - theme: brand


### PR DESCRIPTION
- Range: c3d3bc0...e008551

----

Explanation: this is an example of the translation (zh) workflow.

Preparation:
1. Set up a _checkpoint_ branch named `docs-sync-<lang>`, like `docs-sync-zh`. This branch is always synced to the commit of the original docs that the latest translation (zh) is corresponding to.
2. This checkpoint branch would be only updated if the translation is synced to a nearer commit of the original docs (usually the HEAD of the `main` branch at that moment).

Every round of sync-up:
1. See what we need to be translated so far e.g.
	- `git diff docs-sync-zh..main packages/docs # > debug.log`, or
	- https://github.com/Jinjiang/router/compare/docs-sync-zh...main (only see the changes in `packages/docs/*`)
2. Create a new casual branch on your own e.g. `jinjiang/translate/zh-2023-02-16`.
3. Translate all the updates into `packages/docs/zh/*` accordingly
4. Commit with message like `docs(zh): sync update to e008551` and create a PR for that.
5. Review, approve, and merge.
6. Merge the original hash (`e008551`) to the checkpoint branch `docs-sync-zh` for the next batch of sync-up.

![SCR-20230216-iw7](https://user-images.githubusercontent.com/206848/219282182-7c157f55-f486-43ac-a4c3-39c79711bc4a.png)

Additionally, on the README/homepage, we can leave some links for each language to their own GitHub compare like [this](https://github.com/Jinjiang/router/compare/docs-sync-zh...main) to encourage people for a quick look.

Technically, step 6 could be done automatically by a GitHub action in the future. We can also periodically detect and remind ourselves whether there is anything new to translate by a bot if necessary. However, I didn't prepare that yet.

/cc @posva @johnsoncodehk @kiaking